### PR TITLE
Add CONTRIBUTING, CODEOWNERS, .editorconfig, .clang-format, .clang-tidy

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,21 @@
+---
+BasedOnStyle: LLVM
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ColumnLimit: 120
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortLambdasOnASingleLine: All
+BreakBeforeBraces: Attach
+AlwaysBreakTemplateDeclarations: Yes
+AlignAfterOpenBracket: Align
+AllowAllArgumentsOnNextLine: true
+BinPackArguments: true
+BinPackParameters: true
+SortIncludes: Never
+IncludeBlocks: Preserve
+IndentAccessModifiers: false
+DerivePointerAlignment: false
+PointerAlignment: Left
+SpaceBeforeParens: ControlStatements

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,48 @@
+---
+# clang-tidy configuration for Dasher-GTK frontend code.
+# Mirrors DasherCore's config — focused on real bugs, not style modernization.
+#
+# Run with: clang-tidy -p build/ src/your_file.cpp
+
+Checks: >
+  -*,
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-narrowing-conversions,
+  -bugprone-assignment-in-if,
+  -bugprone-virtual-call,
+  -bugprone-reserved-identifier,
+  cert-*,
+  -cert-err58-cpp,
+  -cert-err34-c,
+  -cert-err33-c,
+  -cert-dcl50-cpp,
+  -cert-dcl37-c,
+  -cert-dcl51-cpp,
+  -cert-dcl16-c,
+  clang-analyzer-*,
+  -clang-analyzer-core.NullDereference,
+  -clang-analyzer-core.CallAndMessage,
+  -clang-analyzer-core.UndefinedBinaryOperatorResult,
+  -clang-analyzer-core.uninitialized.Branch,
+  -clang-analyzer-optin.cplusplus.VirtualCall,
+  clang-diagnostic-*,
+  cppcoreguidelines-pro-type-cstyle-cast,
+  -cppcoreguidelines-pro-type-static-cast-downcast,
+  cppcoreguidelines-slicing,
+  performance-*,
+  -performance-enum-size,
+  -performance-unnecessary-value-param,
+  -performance-trivially-destructible,
+  -performance-avoid-endl,
+  -performance-no-int-to-ptr,
+
+WarningsAsErrors: ''
+
+HeaderFilterRegex: '.*src/.*\.h$'
+
+CheckOptions:
+  - key:   modernize-use-override.IgnoreDestructors
+    value: '1'
+  - key:   performance-unnecessary-value-param.AllowedTypes
+    value: 'std::string;std::function'

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{cpp,c,h,hpp}]
+indent_style = space
+indent_size = 4
+max_line_length = 120
+
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+[*.css]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[CMakeLists.txt]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,51 @@
+name: DCO
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dco:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check Signed-off-by on all commits
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          commits=$(git rev-list --no-merges "$BASE_SHA".."$HEAD_SHA")
+          missing=0
+          for sha in $commits; do
+            body=$(git log -1 --format='%B' "$sha")
+            if ! echo "$body" | grep -qE '^Signed-off-by: .+ <.+@.+>'; then
+              short=$(git rev-parse --short "$sha")
+              subject=$(git log -1 --format='%s' "$sha")
+              echo "::error file=::Missing Signed-off-by on commit $short ($subject)"
+              missing=$((missing + 1))
+            fi
+          done
+          if [ "$missing" -gt 0 ]; then
+            echo ""
+            echo "❌ $missing commit(s) missing Signed-off-by."
+            echo ""
+            echo "To fix, rebase with signoff:"
+            echo "  git rebase --signoff origin/\${{ github.base_ref }}"
+            echo "  git push --force-with-lease"
+            echo ""
+            echo "Or amend the last commit:"
+            echo "  git commit --amend -s --no-edit"
+            echo ""
+            echo "See: https://developercertificate.org/"
+            exit 1
+          fi
+          echo "✅ All commits have Signed-off-by"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# Default owner — all paths not matched below
+* @PapeCoding
+
+# DasherCore submodule — do not edit in this repo
+/DasherCore/ @PapeCoding
+
+# Build system
+/CMakeLists.txt @PapeCoding

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Contributing to Dasher-GTK
+
+Thank you for your interest in improving the GTK frontend for Dasher! This guide
+covers the specifics of this repository. For project-wide conventions (code of
+conduct, security, RFCs), see the
+[organisation CONTRIBUTING](https://github.com/dasher-project/.github/blob/main/.github/CONTRIBUTING.md).
+
+## Quick start
+
+```bash
+git clone --recurse-submodules https://github.com/dasher-project/Dasher-GTK.git
+cd Dasher-GTK
+mkdir build && cd build
+cmake ..
+make -j$(nproc)
+```
+
+The binary and runtime data are placed in `build/Dasher/`. Launch from there:
+`./Dasher/DasherGTK`.
+
+See the [build guide](https://dasher.at/developers/build-guides/gtk/) for
+platform-specific dependencies (GTK4, gtkmm, pkg-config).
+
+## What lives where
+
+| Directory          | Purpose                                                        |
+| :----------------- | :------------------------------------------------------------ |
+| `src/`             | Frontend C++ source (GTK4/gtkmm) — the code you edit           |
+| `src/Engine/`      | Bridge between GTK UI and DasherCore C API                    |
+| `src/Input/`       | Input device handling (SDL3 joystick, dwell-click)             |
+| `src/Output/`      | TTS (rust-tts-wrapper), direct mode                            |
+| `src/Preferences/` | Settings UI                                                    |
+| `src/UIComponents/` | Reusable GTK widgets (Synced* controls bound to CAPI params)  |
+| `DasherCore/`      | **Submodule** — the C++ engine (do not edit here; PR upstream) |
+| `Thirdparty/SDL/`  | **Submodule** — SDL3 (joystick/haptic input only)             |
+| `rust-tts-wrapper/` | **Submodule** — cross-platform TTS with C ABI                |
+| `Resources/`       | UI style, licenses                                             |
+
+## Code style
+
+- **clang-format** (`.clang-format`) — run `clang-format -i src/**/*.cpp src/**/*.h`
+  before committing. The config mirrors DasherCore's conventions (4-space indent,
+  120-column limit, LLVM base style).
+- **clang-tidy** (`.clang-tidy`) — bug-finding checks (bugprone-\*, cert-\*,
+  clang-analyzer-\*, performance-\*). Run via
+  `clang-tidy -p build/ src/your_file.cpp`.
+- **.editorconfig** — enforces indentation and line endings in editors that
+  support it.
+
+## DasherCore changes
+
+DasherCore is a git submodule pointing to
+[dasher-project/DasherCore](https://github.com/dasher-project/DasherCore).
+**Do not modify it inside this repo.** If you need an engine change, open a PR
+against DasherCore directly, then bump the submodule pin here once merged.
+
+## CI
+
+GitHub Actions (`.github/workflows/cmake-multi-platform.yml`) builds on
+Ubuntu, Windows, and macOS across multiple compilers. Your PR must pass on at
+least Ubuntu (the primary platform).
+
+## Definition of Done
+
+- [ ] clang-format clean (`clang-format --dry-run -Werror src/**/*.cpp src/**/*.h`)
+- [ ] Builds on Linux (and ideally macOS/Windows)
+- [ ] No new clang-tidy warnings
+- [ ] If you changed a user-visible capability, update the
+      [feature status matrix](https://dasher.at/status/) (`website` repo:
+      `src/data/feature-status.json`) — the PR template has a checkbox for this
+- [ ] If you changed UX/hardware interaction across platforms, check whether an
+      [RFC](https://github.com/dasher-project/governance/tree/main/rfcs) is needed
+
+## Pull request process
+
+1. Fork and branch from `main`.
+2. Ensure submodules are up to date (`git submodule update --init --recursive`).
+3. Open a PR — the org-level PR template will prompt you on parity, RFCs, and
+   the feature matrix.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thank you for your interest in improving the GTK frontend for Dasher! This guide
 covers the specifics of this repository. For project-wide conventions (code of
 conduct, security, RFCs), see the
-[organisation CONTRIBUTING](https://github.com/dasher-project/.github/blob/main/.github/CONTRIBUTING.md).
+[organisation CONTRIBUTING](https://github.com/dasher-project/.github/blob/main/CONTRIBUTING.md).
 
 ## Quick start
 
@@ -65,6 +65,7 @@ least Ubuntu (the primary platform).
 - [ ] clang-format clean (`clang-format --dry-run -Werror src/**/*.cpp src/**/*.h`)
 - [ ] Builds on Linux (and ideally macOS/Windows)
 - [ ] No new clang-tidy warnings
+- [ ] Commits are signed off (DCO) — `git commit -s`
 - [ ] If you changed a user-visible capability, update the
       [feature status matrix](https://dasher.at/status/) (`website` repo:
       `src/data/feature-status.json`) — the PR template has a checkbox for this


### PR DESCRIPTION
Wave 2 governance for the GTK frontend.

**Adds:**
- **CONTRIBUTING.md** — build quick-start, directory map, clang-format/clang-tidy guidance, CI matrix info, Definition of Done with feature-matrix checkbox
- **CODEOWNERS** — @PapeCoding as default owner
- **.editorconfig** — 4-space C++, 2-space JSON/CSS/CMake, UTF-8/LF
- **.clang-format** — mirrors DasherCore's config (LLVM base, 4-space indent, 120-col, left-aligned pointers)
- **.clang-tidy** — mirrors DasherCore's bug-focused checks (bugprone-*, cert-*, clang-analyzer-*, performance-*)

Part of the cross-platform governance rollout (org .github, governance repo, website handbook all merged). See https://dasher.at/developers/ for the contributor experience these files plug into.