### PR TITLE
Bump DasherCore to v0.1.5; wire log callback; resolve params by name

### DIFF
--- a/src/Engine/DasherBridge.cpp
+++ b/src/Engine/DasherBridge.cpp
@@ -290,11 +290,19 @@ void DasherBridge::log_callback_trampoline(int level, const char* message, void*
     // fatal under GLib and would abort the process.
     GLogLevelFlags glib_level;
     switch (level) {
-        case 0:  glib_level = G_LOG_LEVEL_DEBUG;    break;
-        case 1:  glib_level = G_LOG_LEVEL_INFO;     break;
-        case 2:  glib_level = G_LOG_LEVEL_WARNING;  break;
-        case 3:
-        default: glib_level = G_LOG_LEVEL_CRITICAL; break;
+    case 0:
+        glib_level = G_LOG_LEVEL_DEBUG;
+        break;
+    case 1:
+        glib_level = G_LOG_LEVEL_INFO;
+        break;
+    case 2:
+        glib_level = G_LOG_LEVEL_WARNING;
+        break;
+    case 3:
+    default:
+        glib_level = G_LOG_LEVEL_CRITICAL;
+        break;
     }
     g_log("DasherCore", glib_level, "%s", message ? message : "");
 }

--- a/src/Engine/DasherBridge.cpp
+++ b/src/Engine/DasherBridge.cpp
@@ -1,6 +1,7 @@
 #include "DasherBridge.h"
 #include <cstring>
 #include <iostream>
+#include <glib.h>
 
 DasherBridge::DasherBridge(const std::string& data_dir, const std::string& user_dir) {
     m_start_time = std::chrono::steady_clock::now();
@@ -10,6 +11,14 @@ DasherBridge::DasherBridge(const std::string& data_dir, const std::string& user_
     if (!m_ctx) {
         std::string err = error ? error : "Unknown error creating Dasher context";
         std::cerr << "DasherBridge: " << err << std::endl;
+    }
+
+    if (m_ctx) {
+        // Route DasherCore's internal diagnostic logging to GLib so it integrates
+        // with GTK's structured logging (stderr / journald). Default to warnings
+        // and above (level 2); debug/info messages are discarded inside the engine
+        // at zero cost. Without this call DasherCore silently drops all log output.
+        dasher_set_log_callback(m_ctx, log_callback_trampoline, nullptr, /*min_level=*/2);
     }
 }
 
@@ -140,6 +149,14 @@ void DasherBridge::set_string_parameter(int key, const std::string& value) {
     if (m_ctx) dasher_set_string_parameter(m_ctx, key, value.c_str());
 }
 
+int DasherBridge::find_parameter_key(const std::string& enum_key_name) const {
+    // Resolve a parameter by its stable enum name (e.g. "LP_MAX_BITRATE") to its
+    // current integer key. The numeric values of Dasher::Parameter are an
+    // implementation detail of DasherCore and shift between releases, so callers
+    // must never hardcode them. Returns -1 if the name is unknown.
+    return dasher_find_parameter_key(enum_key_name.c_str());
+}
+
 int DasherBridge::get_parameter_count() const {
     return dasher_get_parameter_count();
 }
@@ -264,6 +281,22 @@ void DasherBridge::output_callback_trampoline(int event_type, const char* text, 
     if (self && self->m_output_callback) {
         self->m_output_callback(event_type, text ? text : "");
     }
+}
+
+void DasherBridge::log_callback_trampoline(int level, const char* message, void* /*user_data*/) {
+    // Map DasherCore log levels (0=debug, 1=info, 2=warning, 3=error) onto GLib
+    // log levels under the "DasherCore" domain. Note: engine "error" maps to
+    // G_LOG_LEVEL_CRITICAL rather than G_LOG_LEVEL_ERROR, because the latter is
+    // fatal under GLib and would abort the process.
+    GLogLevelFlags glib_level;
+    switch (level) {
+        case 0:  glib_level = G_LOG_LEVEL_DEBUG;    break;
+        case 1:  glib_level = G_LOG_LEVEL_INFO;     break;
+        case 2:  glib_level = G_LOG_LEVEL_WARNING;  break;
+        case 3:
+        default: glib_level = G_LOG_LEVEL_CRITICAL; break;
+    }
+    g_log("DasherCore", glib_level, "%s", message ? message : "");
 }
 
 int64_t DasherBridge::get_current_time_ms() const {

--- a/src/Engine/DasherBridge.h
+++ b/src/Engine/DasherBridge.h
@@ -62,6 +62,8 @@ public:
     std::string get_string_parameter(int key) const;
     void set_string_parameter(int key, const std::string& value);
 
+    int find_parameter_key(const std::string& enum_key_name) const;
+
     int get_parameter_count() const;
     DasherParameterInfo get_parameter_info(int index) const;
     int get_parameter_enum_count(int key) const;
@@ -95,6 +97,7 @@ private:
     std::function<void(int, const std::string&)> m_output_callback;
 
     static void output_callback_trampoline(int event_type, const char* text, void* user_data);
+    static void log_callback_trampoline(int level, const char* message, void* user_data);
 
     std::chrono::time_point<std::chrono::steady_clock> m_start_time;
 };

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -12,9 +12,13 @@ static Cairo::ToyFontFace::Slant getSlantFromPango(Pango::Style s) {
 }
 
 MainWindow::MainWindow()
-    : m_alphabet_chooser(95, m_canvas.bridge, m_canvas.bridge->get_parameter_string_values(95))
-    , m_speed_adjustment(30, m_canvas.bridge, 20, 400, 5)
-    , m_learning_switch(15, m_canvas.bridge)
+    // Resolve parameter keys by their stable enum names rather than hardcoding
+    // numeric indices: Dasher::Parameter values are an internal detail of
+    // DasherCore and are renumbered between releases.
+    : m_alphabet_chooser(m_canvas.bridge->find_parameter_key("SP_ALPHABET_ID"), m_canvas.bridge,
+                         m_canvas.bridge->get_parameter_string_values(m_canvas.bridge->find_parameter_key("SP_ALPHABET_ID")))
+    , m_speed_adjustment(m_canvas.bridge->find_parameter_key("LP_MAX_BITRATE"), m_canvas.bridge, 20, 400, 5)
+    , m_learning_switch(m_canvas.bridge->find_parameter_key("BP_LM_ADAPTIVE"), m_canvas.bridge)
     , m_color_chooser(m_canvas.bridge)
     , m_preferences_window(m_canvas.bridge)
 {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -15,14 +15,12 @@ MainWindow::MainWindow()
     // Resolve parameter keys by their stable enum names rather than hardcoding
     // numeric indices: Dasher::Parameter values are an internal detail of
     // DasherCore and are renumbered between releases.
-    : m_alphabet_chooser(m_canvas.bridge->find_parameter_key("SP_ALPHABET_ID"), m_canvas.bridge,
-                         m_canvas.bridge->get_parameter_string_values(
-                             m_canvas.bridge->find_parameter_key("SP_ALPHABET_ID")))
-    , m_speed_adjustment(m_canvas.bridge->find_parameter_key("LP_MAX_BITRATE"), m_canvas.bridge, 20, 400, 5)
-    , m_learning_switch(m_canvas.bridge->find_parameter_key("BP_LM_ADAPTIVE"), m_canvas.bridge)
-    , m_color_chooser(m_canvas.bridge)
-    , m_preferences_window(m_canvas.bridge)
-{
+    : m_alphabet_chooser(
+          m_canvas.bridge->find_parameter_key("SP_ALPHABET_ID"), m_canvas.bridge,
+          m_canvas.bridge->get_parameter_string_values(m_canvas.bridge->find_parameter_key("SP_ALPHABET_ID"))),
+      m_speed_adjustment(m_canvas.bridge->find_parameter_key("LP_MAX_BITRATE"), m_canvas.bridge, 20, 400, 5),
+      m_learning_switch(m_canvas.bridge->find_parameter_key("BP_LM_ADAPTIVE"), m_canvas.bridge),
+      m_color_chooser(m_canvas.bridge), m_preferences_window(m_canvas.bridge) {
     Glib::RefPtr<Gtk::CssProvider> css = Gtk::CssProvider::create();
     css->load_from_path("./UIStyle.css");
     get_style_context()->add_provider_for_display(Gdk::Display::get_default(), css, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -16,7 +16,8 @@ MainWindow::MainWindow()
     // numeric indices: Dasher::Parameter values are an internal detail of
     // DasherCore and are renumbered between releases.
     : m_alphabet_chooser(m_canvas.bridge->find_parameter_key("SP_ALPHABET_ID"), m_canvas.bridge,
-                         m_canvas.bridge->get_parameter_string_values(m_canvas.bridge->find_parameter_key("SP_ALPHABET_ID")))
+                         m_canvas.bridge->get_parameter_string_values(
+                             m_canvas.bridge->find_parameter_key("SP_ALPHABET_ID")))
     , m_speed_adjustment(m_canvas.bridge->find_parameter_key("LP_MAX_BITRATE"), m_canvas.bridge, 20, 400, 5)
     , m_learning_switch(m_canvas.bridge->find_parameter_key("BP_LM_ADAPTIVE"), m_canvas.bridge)
     , m_color_chooser(m_canvas.bridge)


### PR DESCRIPTION
## Summary

Bumps the **DasherCore** submodule from a stale pre-alphabet commit (`d2da83e`) to the tagged release **[v0.1.5](https://github.com/dasher-project/DasherCore/releases/tag/v0.1.5)** (`26e6252`) and adapts the GTK frontend to it. Two engine changes in v0.1.5 needed handling:

1. **Logging is now a callback.** v0.1.5 replaced `CFileLogger`/`CBasicLog`/`UserLog` with a single C API — `dasher_set_log_callback(ctx, cb, user_data, min_level)` (see [C API docs](https://github.com/dasher-project/DasherCore/blob/main/docs/C_API.md)). A null callback silently discards messages, and the old `dasher.log`/training-file CWD leaks are gone. Added a trampoline in `DasherBridge` that forwards engine log levels to **GLib structured logging** under the `"DasherCore"` domain, registered immediately after `dasher_create`.
2. **The `Dasher::Parameter` enum was renumbered**, which broke `MainWindow`'s hardcoded parameter indices (`95/30/15`) and crashed the app at startup (`SettingsStore.cpp:126` assertion). Keys are now resolved by their stable enum **name** via the new `dasher_find_parameter_key` API, so the frontend no longer depends on enum ordering.

This also brings v0.1.5's native **v5 alphabet XML** reading ([RFC 0005](https://github.com/dasher-project/governance/blob/main/rfcs/0005-v5-migration.md)) and the v5 special-character elements (`<space>`/`<paragraph>`/`<control>`) to Dasher-GTK.

**Engine release:** [DasherCore v0.1.5](https://github.com/dasher-project/DasherCore/releases/tag/v0.1.5) · **Issue / RFC:** _n/a_

## What to review

- **Log-level mapping** (`DasherBridge::log_callback_trampoline`): engine `0/1/2/3` → GLib `DEBUG/INFO/WARNING/CRITICAL`. Engine "error" is deliberately mapped to `G_LOG_LEVEL_CRITICAL`, **not** `G_LOG_LEVEL_ERROR` (which is *fatal* under GLib and would abort the process). `min_level = 2` (warnings+) keeps normal runs quiet; debug/info are dropped inside the engine at zero cost. **Is GLib the sink you want, and is warnings+ the right default** — or would you prefer stderr / a file, or a different threshold?
- **Parameter name resolution** (`MainWindow` ctor): now `find_parameter_key("SP_ALPHABET_ID" / "LP_MAX_BITRATE" / "BP_LM_ADAPTIVE")`. Worth confirming those are the intended params (they map to the old `95 / 30 / 15`).
- **Submodule pin** is the **v0.1.5 tag**, not `main` — `main` has a later `dasher_reset_settings()` addition that this PR intentionally excludes, per the move to tagged-release pins.

## Type of change

- [x] Bug fix _(startup crash from the enum renumbering)_
- [ ] New feature
- [ ] Cross-platform / parity change
- [x] Refactor / tooling / docs _(dependency bump + adapt to new logging/parameter APIs)_

## Cross-platform impact

- [x] Changes a capability users see on **other platforms.** Adopting v0.1.5 brings **v5/v6 alphabet-file reading** to Dasher-GTK; Dasher-Windows and Dasher-Apple already consume v0.1.5. **No feature-matrix PR is linked** — flagging for the reviewer to confirm whether the per-frontend matrix wants a GTK update.
- [ ] Introduces a **new UX or hardware interaction.** _(No — logging + parameter resolution are internal integration only.)_

## Verification

- **Build:** Linux Debug, clean. ✅
- **Engine tests against this pin:** DasherCore alphabet-XML + CAPI suites — **167 assertions**, all passing. ✅
- **Runtime smoke (headless / Xvfb):** **475 alphabets** load; v6 *"English, lower case"* and v5 *"Afrikaans with punctuation and numerals"* (a `oldAlphabets/` v5-format file) both present and switchable; log callback fires with correct level mapping; **no `dasher.log` written to CWD.** ✅
- **Style:** `clang-format` clean and `clang-tidy` **0 new warnings** on the changed files. ✅

## Notes / follow-ups

- **Lazy alphabet dropdown:** `MainWindow` reads the alphabet list before the canvas realizes, so the initial list can be empty until a refresh. **Pre-existing** behaviour, not introduced by this bump — candidate follow-up: refresh the dropdown after canvas realize.
- DCO `-s` signed; no AI/co-author footer.
