### PR TITLE
Fix Windows CI build and wire up cross-platform tests

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -9,12 +9,6 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
 
-    # Windows is informational only: the rust-tts-wrapper `sapi` feature does not
-    # yet build against the windows crate (tracked upstream — needs a windows 0.62
-    # migration done on a Windows host). Keep the job running for visibility but do
-    # not let it block CI; Linux and macOS fully gate the build.
-    continue-on-error: ${{ matrix.os == 'windows-2025' }}
-
     strategy:
       # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
       fail-fast: false

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -93,7 +93,10 @@ jobs:
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
-    
+
+    - name: Test
+      run: ctest --test-dir ${{ steps.strings.outputs.build-output-dir }} --build-config ${{ matrix.build_type }} --output-on-failure
+
     - name: Upload Binaries
       uses: actions/upload-artifact@v4
       with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,4 +8,4 @@
 	branch = release-3.2.x
 [submodule "rust-tts-wrapper"]
 	path = rust-tts-wrapper
-	url = https://github.com/AACTools/rust-tts-wrapper.git
+	url = https://github.com/owenpkent/rust-tts-wrapper.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,13 @@ set(TTS_WRAPPER_BUILD_DIR "${CMAKE_BINARY_DIR}/rust-tts-wrapper")
 set(TTS_WRAPPER_VERSION "0.1.0" CACHE STRING "rust-tts-wrapper version to download")
 
 if(EXISTS "${TTS_WRAPPER_DIR}/Cargo.toml")
-	set(TTS_WRAPPER_LIB "${TTS_WRAPPER_BUILD_DIR}/release/librust_tts_wrapper.a")
+	# cargo names the staticlib per target: MSVC produces rust_tts_wrapper.lib,
+	# GNU/Unix toolchains produce librust_tts_wrapper.a.
+	if(WIN32)
+		set(TTS_WRAPPER_LIB "${TTS_WRAPPER_BUILD_DIR}/release/rust_tts_wrapper.lib")
+	else()
+		set(TTS_WRAPPER_LIB "${TTS_WRAPPER_BUILD_DIR}/release/librust_tts_wrapper.a")
+	endif()
 	set(TTS_WRAPPER_HEADER "${TTS_WRAPPER_DIR}/include/tts_wrapper.h")
 
 	if(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,11 @@ if(TARGET tts_wrapper)
 	if(APPLE)
 		target_link_libraries(Dasher PRIVATE "-framework AVFAudio" "-framework Foundation" "-lobjc")
 	elseif(WIN32)
+		# The rust-tts-wrapper staticlib pulls in Rust std, getrandom and rustls,
+		# whose native dependencies are not propagated when the archive is linked
+		# by MSVC instead of by cargo. Mirror `rustc --print native-static-libs`.
+		target_link_libraries(Dasher PRIVATE
+			ntdll userenv bcrypt ws2_32 advapi32 crypt32 secur32 ncrypt ole32 oleaut32)
 	else()
 		target_link_libraries(Dasher PRIVATE dl pthread speechd)
 	endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,3 +189,13 @@ endif()
 ###############################
 
 install(DIRECTORY ${CMAKE_BINARY_DIR}/Dasher/ DESTINATION .)
+
+###############################
+# Tests
+###############################
+
+option(BUILD_GTK_TESTS "Build Dasher-GTK unit tests" ON)
+if(BUILD_GTK_TESTS)
+	enable_testing()
+	add_subdirectory(tests)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,4 +24,16 @@ target_include_directories(dasher_unit_tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(dasher_unit_tests PRIVATE doctest::doctest ${GTKMM_LIBRARIES})
 target_link_directories(dasher_unit_tests PRIVATE ${GTKMM_LIBRARY_DIRS})
 
+# The Windows runner's gtkmm/sigc++ are prebuilt release (/MD,
+# _ITERATOR_DEBUG_LEVEL=0) binaries. Building this test in the Debug config with
+# the debug runtime (/MDd, _ITERATOR_DEBUG_LEVEL=2) gives sigc++'s internal slot
+# containers a different STL ABI than the compiled libsigc, corrupting the slot
+# list and crashing on the first signal connect(). The Release job already runs
+# this suite cleanly with /MD, so force the test to the release runtime in every
+# config to match the gtkmm ABI. CMP0091 is NEW here (cmake_minimum 3.20).
+if(MSVC)
+    set_property(TARGET dasher_unit_tests PROPERTY
+        MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+endif()
+
 add_test(NAME dasher_unit_tests COMMAND dasher_unit_tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Unit tests for Dasher-GTK. Kept lightweight: each unit under test is compiled
+# directly into the test binary, so the suite builds without the full app, its
+# git submodules or the Rust TTS wrapper. doctest is fetched at configure time.
+include(FetchContent)
+FetchContent_Declare(
+    doctest
+    GIT_REPOSITORY https://github.com/doctest/doctest.git
+    GIT_TAG v2.4.11
+)
+# doctest v2.4.11 ships cmake_minimum_required(VERSION 3.0); CMake 4.x (the
+# macOS/Windows runners) removed compatibility with minimums below 3.5 and
+# aborts. This variable supplies the 3.5 floor for that dependency and is
+# ignored by the older CMake on the Linux runners.
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+FetchContent_MakeAvailable(doctest)
+
+add_executable(dasher_unit_tests
+    test_dwell_click_handler.cpp
+    ${CMAKE_SOURCE_DIR}/src/Input/DwellClickHandler.cpp
+)
+
+target_include_directories(dasher_unit_tests SYSTEM PRIVATE ${GTKMM_INCLUDE_DIRS})
+target_include_directories(dasher_unit_tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(dasher_unit_tests PRIVATE doctest::doctest ${GTKMM_LIBRARIES})
+target_link_directories(dasher_unit_tests PRIVATE ${GTKMM_LIBRARY_DIRS})
+
+add_test(NAME dasher_unit_tests COMMAND dasher_unit_tests)

--- a/tests/test_dwell_click_handler.cpp
+++ b/tests/test_dwell_click_handler.cpp
@@ -1,0 +1,121 @@
+// Unit tests for DwellClickHandler — the dwell-to-click input helper used for
+// hands-light / switch-free access. These cover the deterministic geometry,
+// input clamping and state-machine behaviour. The single timing case uses a
+// real short wait because the handler reads steady_clock directly.
+// On Windows, doctest's DOCTEST_CONFIG_IMPLEMENT drags in <windows.h>, whose
+// macros collide with glibmm (e.g. Glib::IOChannel::read), breaking the gtkmm
+// headers with cascading C2059/C3646 errors. Parse the glibmm/gtkmm headers
+// first so they compile cleanly, then bring in the doctest implementation.
+#include <glibmm/init.h>
+
+#include "Input/DwellClickHandler.h"
+
+#include <chrono>
+#include <thread>
+
+#define DOCTEST_CONFIG_IMPLEMENT
+#include <doctest/doctest.h>
+
+TEST_CASE("duration is clamped to a 100ms floor") {
+    DwellClickHandler h;
+    CHECK(h.get_duration_ms() == 800); // default
+    h.set_duration_ms(50);
+    CHECK(h.get_duration_ms() == 100);
+    h.set_duration_ms(1000);
+    CHECK(h.get_duration_ms() == 1000);
+}
+
+TEST_CASE("radius is clamped to a 1.0 floor") {
+    DwellClickHandler h;
+    h.set_radius(0.0f);
+    CHECK(h.get_radius() == doctest::Approx(1.0f));
+    h.set_radius(25.0f);
+    CHECK(h.get_radius() == doctest::Approx(25.0f));
+}
+
+TEST_CASE("a disabled handler never tracks or activates") {
+    DwellClickHandler h;
+    CHECK_FALSE(h.get_enabled());
+    h.on_pointer_move(10.0f, 10.0f);
+    CHECK_FALSE(h.is_active());
+    CHECK(h.get_progress() == doctest::Approx(0.0f));
+}
+
+TEST_CASE("first move after enabling starts a dwell at that point") {
+    DwellClickHandler h;
+    h.set_enabled(true);
+    h.on_pointer_move(10.0f, 20.0f);
+    CHECK(h.is_active());
+    CHECK(h.get_center_x() == doctest::Approx(10.0f));
+    CHECK(h.get_center_y() == doctest::Approx(20.0f));
+}
+
+TEST_CASE("movement within the radius keeps the dwell centre") {
+    DwellClickHandler h;
+    h.set_enabled(true);
+    h.set_radius(20.0f);
+    h.on_pointer_move(0.0f, 0.0f); // start dwell at the origin
+    h.on_pointer_move(5.0f, 5.0f); // ~7.07px, inside the 20px radius
+    CHECK(h.get_center_x() == doctest::Approx(0.0f));
+    CHECK(h.get_center_y() == doctest::Approx(0.0f));
+}
+
+TEST_CASE("movement beyond the radius restarts the dwell at the new point") {
+    DwellClickHandler h;
+    h.set_enabled(true);
+    h.set_radius(20.0f);
+    h.on_pointer_move(0.0f, 0.0f);
+    h.on_pointer_move(100.0f, 0.0f); // 100px, outside the 20px radius
+    CHECK(h.get_center_x() == doctest::Approx(100.0f));
+    CHECK(h.get_center_y() == doctest::Approx(0.0f));
+}
+
+TEST_CASE("movement exactly at the radius does not restart the dwell") {
+    // The reset uses a strict '>' comparison, so a point on the boundary holds.
+    DwellClickHandler h;
+    h.set_enabled(true);
+    h.set_radius(10.0f);
+    h.on_pointer_move(0.0f, 0.0f);
+    h.on_pointer_move(10.0f, 0.0f); // distance == radius, not greater
+    CHECK(h.get_center_x() == doctest::Approx(0.0f));
+}
+
+TEST_CASE("disabling cancels an in-progress dwell") {
+    DwellClickHandler h;
+    h.set_enabled(true);
+    h.on_pointer_move(0.0f, 0.0f);
+    REQUIRE(h.is_active());
+    h.set_enabled(false);
+    CHECK_FALSE(h.is_active());
+}
+
+TEST_CASE("no click is emitted before the dwell duration elapses") {
+    DwellClickHandler h;
+    int clicks = 0;
+    h.signal_dwell_click().connect([&clicks]() { ++clicks; });
+    h.set_enabled(true);
+    h.set_duration_ms(100);
+    h.on_pointer_move(0.0f, 0.0f);
+    h.on_frame(); // ~0ms elapsed
+    CHECK(clicks == 0);
+}
+
+TEST_CASE("a click is emitted once the dwell duration elapses") {
+    DwellClickHandler h;
+    int clicks = 0;
+    h.signal_dwell_click().connect([&clicks]() { ++clicks; });
+    h.set_enabled(true);
+    h.set_duration_ms(100);
+    h.on_pointer_move(0.0f, 0.0f);
+    std::this_thread::sleep_for(std::chrono::milliseconds(150));
+    h.on_frame();
+    CHECK(clicks == 1);
+    CHECK_FALSE(h.is_active()); // the handler latches after firing
+}
+
+int main(int argc, char** argv) {
+    Glib::init(); // on_frame() schedules an unclick via Glib::signal_timeout()
+    doctest::Context context;
+    context.applyCommandLine(argc, argv);
+    return context.run();
+}


### PR DESCRIPTION
## Summary

Makes the Windows CI build green and runs the unit tests across the whole matrix. Windows had been kept non-blocking because the `rust-tts-wrapper` SAPI backend would not compile under windows-rs 0.61. This fixes that, the follow-on Windows link issues it unmasked, wires `ctest` into the build, and re-enables Windows as a blocking gate.

Rebased onto the current `feature/v6-capi-migration`, so it sits on top of the recent CI work and does **not** re-add the libspeechd install (already present).

What is in here:

1. **Bump `rust-tts-wrapper`** to a Windows-buildable SAPI commit, and temporarily point the submodule URL at the fork that carries the fix. Upstream fix PR: AACTools/rust-tts-wrapper#5. Once it merges, revert the `.gitmodules` URL to AACTools and re-pin.
2. **CMake: per-target Rust staticlib name** — `rust_tts_wrapper.lib` on MSVC vs `librust_tts_wrapper.a` elsewhere (was `LNK1181`).
3. **CMake: Windows system libs** for the Rust staticlib — `userenv` / `ntdll` / `bcrypt` and friends, which are not propagated when MSVC (not cargo) links the archive (was `LNK2019`).
4. **Tests** — port the lightweight DwellClickHandler doctest suite and a `ctest` step so the matrix actually runs tests.
5. **Test: release MSVC runtime** — fixes a Debug-only SIGSEGV from a `/MDd` vs prebuilt `/MD` gtkmm/sigc++ ABI mismatch on the first signal `connect()`.
6. **Re-enable Windows as a blocking gate** — drop the `continue-on-error` stopgap now that Windows is green.

Issue / RFC: none (build/tooling fix; no RFC required per governance).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Cross-platform / parity change
- [x] Refactor / tooling / docs

## Cross-platform impact

- [ ] This changes a capability that users see on **other platforms**.
      _Confirmed platform-specific-only: this is Windows build/link infrastructure plus CI, with no user-visible capability change, so no feature-matrix update is needed._
- [ ] This introduces a **new UX or hardware interaction**.
      _No UX or hardware change, so no RFC is needed._

## Definition of Done

- [x] CI is green (build + tests + lint + format, as applicable) — lint/format already green; the build+test matrix was validated green on the equivalent pre-rebase branch and this PR's run is completing.
- [x] Tests added for new behaviour — wired the existing DwellClickHandler doctest suite to build and run in CI via `ctest`.
- [ ] Feature matrix updated if this affects a cross-platform capability — N/A, no capability change.
- [ ] Docs / changelog updated if the change is user-facing — N/A, not user-facing.
- [x] Commits are signed off (DCO) — `git commit -s`.

## Notes

- The README's second documented Windows blocker (glibmm/MSVC `iochannel.h` C2059/C2143) did **not** manifest in this CI; all C++ compiled clean.
- Follow-up once AACTools/rust-tts-wrapper#5 merges: revert the submodule URL to AACTools and re-pin the submodule.
