### PR TITLE
chore: untrack dasher.log and ignore *.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build
 /.cache
 /.vscode
+*.log


### PR DESCRIPTION
Removes the accidentally-committed empty \dasher.log\ and adds \*.log\ to \.gitignore\.

Follow-up cleanup after the v6-capi-migration merge (#9).